### PR TITLE
Support multiple short domains

### DIFF
--- a/content-service/config.json
+++ b/content-service/config.json
@@ -3,5 +3,8 @@
   "acao_list": [
     "http://localhost:3001"
   ],
-  "short_url": "http://localhost:3002"
+  "short_url": [
+    "https://pm0.io",
+    "http://localhost:3002"
+  ]
 }

--- a/content-service/config.json
+++ b/content-service/config.json
@@ -4,7 +4,7 @@
     "http://localhost:3001"
   ],
   "short_url": [
-    "https://pm0.io",
-    "http://localhost:3002"
+    "http://localhost:3001",
+    "https://pm0.io"
   ]
 }

--- a/content-service/server/database/utils.js
+++ b/content-service/server/database/utils.js
@@ -2,9 +2,19 @@ const nodeUrl = require('url');
 const resolveUrl = nodeUrl.resolve;
 const nodePath = require('path');
 const { shortIdToNum, numToShortId, } = require('../utils/shortid');
+const SHORT_URLS = require('../../config.json').short_url;
+const SHORT_URL = SHORT_URLS[0];
 
-const SHORT_URL = require('../../config.json').short_url;
-const SHORT_URL_KEY = asDomainAndProtocolKey(require('../../config.json').short_url);
+if (!SHORT_URL) {
+  throw new Error('You must specify at least one short_url in the configuration file');
+}
+
+// Build a set of short URLs from the config, we can then test incoming
+// requests based on membership in the set
+const shortUrls = SHORT_URLS.reduce((set, shortUrl) => {
+  set.add(asDomainAndProtocolKey(shortUrl));
+  return set;
+}, new Set());
 
 // Take a URL and reduce it to a key based on the protocol and
 // hostname - inclusive of port number
@@ -15,8 +25,7 @@ function asDomainAndProtocolKey(url) {
 
 function shortUrlToId(url) {
   const parsedUrl = nodeUrl.parse(url);
-  const isShortUrl =
-    asDomainAndProtocolKey(url) === SHORT_URL_KEY;
+  const isShortUrl = shortUrls.has(asDomainAndProtocolKey(url));
 
   if (!isShortUrl) {
     return false;

--- a/content-service/test/test-v1-api.js
+++ b/content-service/test/test-v1-api.js
@@ -7,8 +7,11 @@ const request = require('supertest-as-promised');
 const app = require('../server/app');
 const {
   api_key: API_KEY,
-  short_url: SHORT_URL,
+  short_url,
 } = require('../config.json');
+
+// Uses the first in the config as the SHORT_URL
+const SHORT_URL = short_url[0];
 const path = require('path');
 const nodeUrl = require('url');
 


### PR DESCRIPTION
This is so we can support 'https://tengam.org' and 'https://pm0.io' as short URL domains at the same time.